### PR TITLE
MAG-28: fetch locations with associated media files

### DIFF
--- a/app/Http/Resources/LocationResource.php
+++ b/app/Http/Resources/LocationResource.php
@@ -14,6 +14,22 @@ class LocationResource extends JsonResource
      */
     public function toArray($request)
     {
-        return parent::toArray($request);
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'catchphrase' => $this->catchphrase,
+            'description' => $this->description,
+            'color_tag' => $this->color_tag,
+            'icon' => $this->icon,
+            'lat' => $this->lat,
+            'lng' => $this->lng,
+            'background' => FileResource::collection($this->mediaFor('background')),
+            'carousel' => FileResource::collection($this->mediaFor('carousel')),
+        ];
+    }
+
+    private function mediaFor(string $useCase)
+    {
+        return $this->media()->useCase($useCase)->get();
     }
 }

--- a/app/Media.php
+++ b/app/Media.php
@@ -17,4 +17,9 @@ class Media extends Model
     {
         return $this->morphMany(Media::class, 'modelable', 'model_type', 'model_primary_key', 'id');
     }
+
+    public function scopeUseCase($query, $useCase)
+    {
+        return $query->where('use_case', $useCase);
+    }
 }

--- a/database/factories/MediaFactory.php
+++ b/database/factories/MediaFactory.php
@@ -7,6 +7,9 @@ use Faker\Generator as Faker;
 
 $factory->define(Media::class, function (Faker $faker) {
     return [
-        //
+        'file_type' => $faker->mimeType,
+        'description' => $faker->sentence,
+        'file_path' => 'fake/path/to/file.extension',
+        'use_case' => $faker->randomElement(['background', 'carousel']),
     ];
 });


### PR DESCRIPTION
 # What does this PR do?

 - introduces query scope for getting associated media for a model by media use case
 - updates location API resource to return formatted media

[Finishes #[MAG-28](https://magicalkenya.atlassian.net/browse/MAG-28?atlOrigin=eyJpIjoiYzg1NjI1ODI5ZDM1NDVhOTgyYzNhMWY5ZmU1ZGFhYjAiLCJwIjoiaiJ9)]